### PR TITLE
chore: add riscv64 in buildx

### DIFF
--- a/.github/workflows/buildx.yaml
+++ b/.github/workflows/buildx.yaml
@@ -19,7 +19,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
 
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/s390x
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/386,linux/s390x,linux/riscv64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
 
       # https://github.com/crazy-max/ghaction-docker-buildx


### PR DESCRIPTION
Tested on visionfive2
```
root@visionfive2-1:~/gost/cmd/gost# uname -a
Linux visionfive2-1 5.15.0-starfive #1 SMP Sun Jun 11 07:48:39 UTC 2023 riscv64 GNU/Linux
root@visionfive2-1:~/gost/cmd/gost# ./gost -V
gost 2.12.0 (go1.22.3 linux/riscv64)
```